### PR TITLE
Add npm scripts (dev/deploy).

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "repository": "",
   "scripts": {
-    "dev": "webpack-dev-server",
+    "dev": "webpack-dev-server --devtool source-map",
     "deploy": "NODE_ENV=production webpack -p"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "version": "0.1.0",
   "description": "",
   "repository": "",
+  "scripts": {
+    "dev": "webpack-dev-server",
+    "deploy": "NODE_ENV=production webpack -p"
+  },
   "devDependencies": {
     "babel-core": "^6.3.26",
     "babel-loader": "^6.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,6 @@ module.exports = {
     path: path.join(__dirname, 'build'),
     filename: 'js/app.js'
   },
-  devtool: 'source-map',
   resolve: {
     extensions: ['', '.js', '.jsx'],
     modulesDirectories: ["src/jsx", "node_modules"]


### PR DESCRIPTION
Adding npm scripts as per https://github.com/MoritzStefaner/ach-ingen-zell/issues/4

To run locally, use `npm run dev`
To build prod, use `npm run deploy`

In production, we set `NODE_ENV=production`, for React (see: https://facebook.github.io/react/downloads.html#npm)

Also, we removed `source-map` from `webpack.config.js` and explicitly added it to `dev` build (assuming you don't want to have source maps in production).
