### PR TITLE
Make RegExp ignore case

### DIFF
--- a/src/jsx/Map.jsx
+++ b/src/jsx/Map.jsx
@@ -18,7 +18,7 @@ export default class Map extends React.Component {
     this.props.data.forEach((x)=>{
       // for each bin
 
-      const myRegexp = new RegExp(this.props.suffix.join('$|') + '$');
+      const myRegexp = new RegExp(this.props.suffix.join('$|') + '$', 'i');
 
       // count matches with suffix
       let hits = x.filter((y)=> y.label.match(myRegexp));


### PR DESCRIPTION
Adding ignore case flag (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
Please double-check the change, I didn't run the software.
Thanks!
